### PR TITLE
Add Spoolman lane synchronization

### DIFF
--- a/src/libslic3r/PresetBundle.cpp
+++ b/src/libslic3r/PresetBundle.cpp
@@ -1939,6 +1939,21 @@ unsigned int PresetBundle::sync_ams_list(unsigned int &unknowns)
     return filament_presets.size();
 }
 
+std::string PresetBundle::find_filament_preset_name_by_spoolman_id(unsigned int spool_id) const
+{
+    if (spool_id == 0)
+        return {};
+
+    for (const Preset& preset : filaments.get_presets()) {
+        if (!preset.is_user())
+            continue;
+        if (preset.config.opt_int("spoolman_spool_id", 0) == static_cast<int>(spool_id))
+            return preset.name;
+    }
+
+    return {};
+}
+
 void PresetBundle::set_calibrate_printer(std::string name)
 {
     if (name.empty()) {

--- a/src/libslic3r/PresetBundle.hpp
+++ b/src/libslic3r/PresetBundle.hpp
@@ -116,6 +116,7 @@ public:
     void            set_num_filaments(unsigned int n, std::vector<std::string> new_colors);
     void            set_num_filaments(unsigned int n, std::string new_col = "");
     unsigned int sync_ams_list(unsigned int & unknowns);
+    std::string find_filament_preset_name_by_spoolman_id(unsigned int spool_id) const;
     //BBS: check whether this is the only edited filament
     bool is_the_only_edited_filament(unsigned int filament_index);
 

--- a/src/slic3r/GUI/Plater.hpp
+++ b/src/slic3r/GUI/Plater.hpp
@@ -28,6 +28,7 @@
 #include "libslic3r/calib.hpp"
 #include "libslic3r/CutUtils.hpp"
 #include "libslic3r/FlushVolCalc.hpp"
+#include <Spoolman.hpp>
 
 #define FILAMENT_SYSTEM_COLORS_NUM      16
 
@@ -207,6 +208,8 @@ private:
     ComboBox* m_bed_type_list = nullptr;
     ScalableButton* connection_btn = nullptr;
     ScalableButton* ams_btn = nullptr;
+
+    bool sync_spoolman_loaded_lanes(const std::map<size_t, SpoolmanSpoolShrPtr>& lane_spools);
 };
 
 class Plater: public wxPanel

--- a/src/slic3r/Utils/Spoolman.hpp
+++ b/src/slic3r/Utils/Spoolman.hpp
@@ -124,6 +124,8 @@ public:
         return m_spools;
     }
 
+    std::map<size_t, SpoolmanSpoolShrPtr> get_spools_by_loaded_lane(bool update = false);
+
     SpoolmanSpoolShrPtr get_spoolman_spool_by_id(unsigned int spool_id, bool update = false)
     {
         if (update || !m_initialized)
@@ -220,6 +222,7 @@ public:
     float remaining_length;
     float used_length;
     bool  archived;
+    int   loaded_lane = -1;
 
     SpoolmanFilamentShrPtr m_filament_ptr;
 


### PR DESCRIPTION
## Summary
- parse loaded lane information from Spoolman spools and expose a lane lookup helper
- add a helper to resolve filament presets by their Spoolman spool id
- synchronize sidebar filament selections from Spoolman loaded lanes when the AMS sync button is pressed, updating colors and spool statistics

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2fe57933c83268326617d92679a0e